### PR TITLE
FIX Conform to SS Mailer API

### DIFF
--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -86,7 +86,7 @@ class Mailer extends SilverstripeMailer
      */
     public function sendPlain($to, $from, $subject, $plainContent, $attachments = [], $headers = [])
     {
-        $this->sendMessage($to, $from, $subject, $htmlContent = '', $plainContent, $attachments, $headers);
+        return $this->sendMessage($to, $from, $subject, $htmlContent = '', $plainContent, $attachments, $headers);
     }
 
     /**
@@ -94,7 +94,7 @@ class Mailer extends SilverstripeMailer
      */
     public function sendHTML($to, $from, $subject, $htmlContent, $attachments = [], $headers = [], $plainContent = '')
     {
-        $this->sendMessage($to, $from, $subject, $htmlContent, $plainContent, $attachments, $headers);
+        return $this->sendMessage($to, $from, $subject, $htmlContent, $plainContent, $attachments, $headers);
     }
 
     /**
@@ -130,10 +130,12 @@ class Mailer extends SilverstripeMailer
         } catch (\Exception $e) {
             // Close and remove any temp files created for attachments, then let the exception bubble up
             $this->closeTempFileHandles();
-            throw $e;
+            return false;
         }
 
         $this->closeTempFileHandles();
+        // this is a stupid API :(
+        return array($to, $subject, $content, $headers, '');
     }
 
     /**

--- a/tests/MailerTest.php
+++ b/tests/MailerTest.php
@@ -256,9 +256,6 @@ class MailerTest extends \SapphireTest
         );
     }
 
-    /**
-     * @expectedException Exception
-     */
     public function testSendMessageExceptionClosesHandles()
     {
         list($to, $from, $subject, $content, $plainContent, $attachments, $headers) = $this->getMockEmail();
@@ -281,11 +278,13 @@ class MailerTest extends \SapphireTest
         $mailer->expects($this->once())
             ->method('closeTempFileHandles');
 
-        $this->invokeMethod(
+        $response = $this->invokeMethod(
             $mailer,
             'sendMessage',
             [$to, $from, $subject, $content, $plainContent, $attachments, $headers]
         );
+
+        $this->assertFalse($response);
     }
 
     public function testBuildMessage()


### PR DESCRIPTION
This makes the Mailer conform (loosely) to SilverStripe standards

- Return false/array when sending messages
- Don't throw exceptions on failed sends